### PR TITLE
feat: add segment elfeed

### DIFF
--- a/mini-echo-segments.el
+++ b/mini-echo-segments.el
@@ -63,6 +63,7 @@
 (declare-function evil-state-property "ext:evil-common")
 (declare-function lsp-workspaces "ext:lsp-mode")
 (declare-function flycheck-count-errors "ext:flycheck")
+(declare-function elfeed-search--count-unread "ext:elfeed")
 
 (defcustom mini-echo-position-format "%l:%c,%p"
   "Format used to display lin, number and percentage in mini echo."
@@ -252,6 +253,11 @@ nil means to use `default-directory'.
 (defface mini-echo-lsp
   '((t (:inherit mini-echo-green)))
   "Face for mini-echo segment of lsp."
+  :group 'mini-echo)
+
+(defface mini-echo-elfeed
+  '((t (:inherit elfeed-search-unread-count-face)))
+  "Face for mini-echo segment of elfeed feeds."
   :group 'mini-echo)
 
 (defvar mini-echo-segment-alist nil)
@@ -676,6 +682,16 @@ Segment appearence depends on var `vc-display-status' and faces like
   (when (and (bound-and-true-p envrc-mode)
              (not (eq envrc--status 'none)))
     (mini-echo-segment--extract envrc-lighter)))
+
+(mini-echo-define-segment "elfeed"
+  "Return unread feeds count via filter from elfeed."
+  :fetch
+  (propertize
+   (let ((bufn "*elfeed-search*"))
+     (if (get-buffer bufn)
+         (string-trim-right
+          (with-current-buffer bufn (elfeed-search--count-unread))
+          "/.*") "")) 'face 'mini-echo-elfeed))
 
 ;; TODO add more segments
 


### PR DESCRIPTION
- with elfeed-search buffer open, it indicates the unread feeds count shown upon filter activated.

Hi @liuyinz 

I had wrote and used elfeed segment way back, thought to just add it here also.

- Basically I have added in simple way of using function used by `elfeed` package itself, con is that it needs `elfeed` buffer to be open.
- I have also trimmed the output string to only represent the unread feeds count. Default output is:
```
100/140:10
```
 - where, 100 is unread count out of filtered list
 - 140 is the filtered feeds list
 - 10 is the feed names
 
 - So trim only gives 100, I thought it was sensible and reduced space for echo area.