### PR TITLE
fix: make `update-func` more compatible

### DIFF
--- a/mini-echo-segments.el
+++ b/mini-echo-segments.el
@@ -283,7 +283,7 @@ nil means to use `default-directory'.
                (setf (mini-echo-segment-fetch segment) ',fetch-func)
                ;; update
                (when (consp ',update)
-                 (defun ,update-func ()
+                 (defun ,update-func (&rest _args)
                    (when (bound-and-true-p mini-echo-mode)
                      ,update))
                  (setf (mini-echo-segment-update segment) ',update-func)


### PR DESCRIPTION
the orignal `update-func` doesn't take any arguments, which will cause errors when advising functions with arguments.

fix #11 .