### PR TITLE
feat: add input-method segment

### DIFF
--- a/mini-echo-segments.el
+++ b/mini-echo-segments.el
@@ -244,6 +244,11 @@ Otherwise, show mise section always."
   "Face for mini-echo segment of macro status."
   :group 'mini-echo)
 
+(defface mini-echo-input-method
+  '((t (:inherit mini-echo-status-local)))
+  "Face for mini-echo segment of input method."
+  :group 'mini-echo)
+
 (defface mini-echo-process
   '((t (:inherit mini-echo-status-global)))
   "Face for mini-echo segment of process."
@@ -613,6 +618,13 @@ Display format is inherited from `battery-mode-line-format'."
                    (format "@%s" (char-to-string evil-this-macro))
                  "Def")))
       (mini-echo-segment--print str 'mini-echo-macro))))
+
+(mini-echo-define-segment "input-method"
+  "Indicator that shows current input method if it is active."
+  :fetch
+  (when current-input-method-title
+    (mini-echo-segment--print (format "LANG: %s" current-input-method-title)
+                              'mini-echo-input-method)))
 
 (mini-echo-define-segment "narrow"
   "Indicator of narrow status of current buffer."

--- a/mini-echo-segments.el
+++ b/mini-echo-segments.el
@@ -623,7 +623,7 @@ Display format is inherited from `battery-mode-line-format'."
   "Indicator that shows current input method if it is active."
   :fetch
   (when current-input-method-title
-    (mini-echo-segment--print (format "LANG: %s" current-input-method-title)
+    (mini-echo-segment--print (format "%s" current-input-method-title)
                               'mini-echo-input-method)))
 
 (mini-echo-define-segment "narrow"


### PR DESCRIPTION
Hi @liuyinz, I've been using your package for a few months and I love it.
Sometimes I write in other languages like spanish and I use Emacs' input-method feature to do so. Emacs' default modeline has an indicator for whenever you activate an input method and I thought of adding a segment that does the same.

Feel free to let me know if you want to merge the changes or modify anything in the code.

Thank you for this amazing package!